### PR TITLE
Adding a function to get td content

### DIFF
--- a/dev/reagent_data_table/dev.cljs
+++ b/dev/reagent_data_table/dev.cljs
@@ -42,9 +42,9 @@
 
                      :td-render-fn (fn [row col-id]
                                      (cond (and (= :name col-id)
-                                                (even? (:id row))) ^{:key (:id row)} [:td [:a {:href (str "http://example.com/pople/" (:name row))} (get row col-id)]]
+                                                (even? (:id row))) [:td [:a {:href (str "http://example.com/pople/" (:name row))} (get row col-id)]]
                                            :else (if (empty? (str (get row col-id)))
-                                                   ^{:key (:id row)} [:td {:style {:background :gold :display :block}} "~~unknowable~~"]
+                                                   [:td {:style {:background :gold :display :block}} "~~unknowable~~"]
                                                    (get row col-id))))
 
                      :filterable-columns [:age :name]

--- a/dev/reagent_data_table/dev.cljs
+++ b/dev/reagent_data_table/dev.cljs
@@ -40,12 +40,12 @@
                      :headers [[:id "ID"] [:name "Name"] [:age "Age"]]
                      :rows    (:table-data @app-state)
 
-                     :td-anchor-attributes-fn (fn [row col-id]
-                                                (when (and (= :name col-id)
-                                                           (even? (:id row)))
-                                                  {:href (str "http://example.com/people/" (:name row))}))
-
-                     :no-data-label [:span.info "~~unknowable~~"]
+                     :td-render-fn (fn [row col-id]
+                                     (cond (and (= :name col-id)
+                                                (even? (:id row))) [:a {:href (str "http://example.com/pople/" (:name row))} (get row col-id)]
+                                           :else (if (empty? (str (get row col-id)))
+                                                   [:span {:style {:background :gold :display :block}} "~~unknowable~~"]
+                                                   (get row col-id))))
 
                      :filterable-columns [:age :name]
                      :filter-label "Search by age or name:"

--- a/dev/reagent_data_table/dev.cljs
+++ b/dev/reagent_data_table/dev.cljs
@@ -42,9 +42,9 @@
 
                      :td-render-fn (fn [row col-id]
                                      (cond (and (= :name col-id)
-                                                (even? (:id row))) [:a {:href (str "http://example.com/pople/" (:name row))} (get row col-id)]
+                                                (even? (:id row))) ^{:key (:id row)} [:td [:a {:href (str "http://example.com/pople/" (:name row))} (get row col-id)]]
                                            :else (if (empty? (str (get row col-id)))
-                                                   [:span {:style {:background :gold :display :block}} "~~unknowable~~"]
+                                                   ^{:key (:id row)} [:td {:style {:background :gold :display :block}} "~~unknowable~~"]
                                                    (get row col-id))))
 
                      :filterable-columns [:age :name]

--- a/src/reagent_data_table/core.cljs
+++ b/src/reagent_data_table/core.cljs
@@ -81,7 +81,7 @@
    `:headers`            - A seq of `[col-id text]` where `col-id` is the key looked up in the row-maps, and `text` is the column heading
    `:rows`               - A seq of maps which make provide the table's data
 
-   `:td-render-fn`       - A fn of two args, row and col-id which returns the content of td tags
+   `:td-render-fn`       - A fn of two args, row and col-id which can return a reagent td element or just the content of it.
 
    `:sortable-columns`   - A seq of `col-id` which dictates which columns will be sortable
    `:filterable-columns` - A seq of `col-id` which dictates which columns will be filterable
@@ -155,7 +155,7 @@
             ^{:key [row table-id]}
             [:tr
              (for [[k _] headers]
-               (let [cell (td-render-fn row k)]
-                 (if (and (vector? cell) (= :td (first cell)))
-                   cell
-                   ^{:key [row k table-id]} [:td cell])))]))]]])))
+               (with-meta (let [cell (td-render-fn row k)]
+                            (if (and (vector? cell) (= :td (first cell)))
+                              cell
+                              [:td cell])) {:key [row k table-id]}))]))]]])))

--- a/src/reagent_data_table/core.cljs
+++ b/src/reagent_data_table/core.cljs
@@ -81,8 +81,7 @@
    `:headers`            - A seq of `[col-id text]` where `col-id` is the key looked up in the row-maps, and `text` is the column heading
    `:rows`               - A seq of maps which make provide the table's data
 
-   `:td-anchor-attributes-fn` - A fn of two args, row and col-id which returns a map like {:href \"/foo?bar\"} so that
-                                cells can be links. Return nil for no link
+   `:td-render-fn`       - A fn of two args, row and col-id which returns the content of td tags
 
    `:sortable-columns`   - A seq of `col-id` which dictates which columns will be sortable
    `:filterable-columns` - A seq of `col-id` which dictates which columns will be filterable
@@ -118,9 +117,13 @@
 
 
 
-    (fn [{:keys [headers rows sortable-columns filterable-columns filter-string sort-columns filter-label td-anchor-attributes-fn]
+    (fn [{:keys [headers rows sortable-columns filterable-columns filter-string sort-columns filter-label td-render-fn]
           :or {filterable-columns []
-               sortable-columns []}}]
+               sortable-columns   []
+               td-render-fn       (fn [row k]
+                                    (if (empty? (str (get row k)))
+                                      no-data-label
+                                      (get row k)))}}]
 
       [:div
        (when (seq filterable-columns)
@@ -158,11 +161,4 @@
              (for [[k _] headers]
                ^{:key [row k table-id]}
                [:td
-                (let [td-content (if (empty? (str (get row k)))
-                                   no-data-label
-                                   (get row k))
-                      anchor-attributes (and td-anchor-attributes-fn (td-anchor-attributes-fn row k))]
-
-                  (if anchor-attributes
-                    [:a (update anchor-attributes :style merge {:display :block}) td-content]
-                    td-content))])]))]]])))
+                (td-render-fn row k)])]))]]])))

--- a/src/reagent_data_table/core.cljs
+++ b/src/reagent_data_table/core.cljs
@@ -94,16 +94,14 @@
    `:table-id`           - The value to use as the HTML `id` attribute for the table.  Must be unique if there are multiple tables shown
    `:table-class`        - The value used for the `class` attribute of the table
                            Defaults to `table table-striped table-bordered` which is OK for Bootstrap
-   `:no-data-label`      - In the case that a value is missing/nil/empty, show this text or component instead
 
    `:table-state-change-fn` - Optionally provide a one-arg fn which is called whenever the state of the table (sorting/filtering) changes
                               This is useful if some other part of your app needs to know about the sorting/filtering (saving user prefs, etc)"
 
 
-  [{:keys [sortable-columns filter-string sort-columns table-state-change-fn table-class table-id no-data-label sort-image-base]
+  [{:keys [sortable-columns filter-string sort-columns table-state-change-fn table-class table-id sort-image-base]
                  :or {table-class "table table-striped table-bordered"
                       table-id    ""
-                      no-data-label nil
                       sort-image-base "/img/"}}]
 
   (let [table-state (reagent/atom {:filter-string (or filter-string "")
@@ -121,9 +119,7 @@
           :or {filterable-columns []
                sortable-columns   []
                td-render-fn       (fn [row k]
-                                    (if (empty? (str (get row k)))
-                                      no-data-label
-                                      (get row k)))}}]
+                                    (get row k))}}]
 
       [:div
        (when (seq filterable-columns)
@@ -159,6 +155,7 @@
             ^{:key [row table-id]}
             [:tr
              (for [[k _] headers]
-               ^{:key [row k table-id]}
-               [:td
-                (td-render-fn row k)])]))]]])))
+               (let [cell (td-render-fn row k)]
+                 (if (and (vector? cell) (= :td (first cell)))
+                   cell
+                   ^{:key [row k table-id]} [:td cell])))]))]]])))


### PR DESCRIPTION
This change replace the td-anchor-attributes-fn with a more generic
function td-content-fn. The new function can be used to get the specific
content of the td tag, that allows more flexibility in creating table
content like having links, conditional style etc.