### PR TITLE
Adding expand-on-click fn to the child-row-opts

### DIFF
--- a/dev/reagent_data_table/dev.cljs
+++ b/dev/reagent_data_table/dev.cljs
@@ -27,6 +27,7 @@
                                (for [[k v] (:info row)]
                                  ^{:key (str row "-info-" (name k))}
                                  [:tr [:td (name k)] [:td v]])]]]))
+   :expand-on-click  (fn [row expanding] (.log js/console (str (:name row) " is " (if expanding "expanding" "collapsing"))))
    :expand-button-alignment :left})
 
 (defn- toggle-child-rows

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent-data-table "2.2.0"
+(defproject reagent-data-table "2.2.1"
   :description "Sortable/filterable tables for reagent people"
   :url "http://github.com/mjg123/reagent-data-table"
   :license {:name "Apache License Version 2.0"

--- a/src/reagent_data_table/core.cljs
+++ b/src/reagent_data_table/core.cljs
@@ -77,17 +77,19 @@
 (defn- toggle-child-row-fn
   "Returns a fn that toggles `:expanded?` for a specific row.
    fn will return args so that it may be composed with a pre-existing on-click handler"
-  [table-state row-data table-id]
+  [table-state row-data table-id expand-on-click]
   (fn [& args]
     (swap! table-state update-in [:child-rows [row-data table-id] :expanded?] not)
+    (let [expanding? (get-in @table-state [:child-rows [row-data table-id] :expanded?])]
+      (expand-on-click row-data expanding?))
     args))
 
 (defn expand-button
-  [{:keys [expanded-class collapsed-class] :or {expanded-class "expanded" collapsed-class "collapsed"}}
+  [{:keys [expanded-class collapsed-class expand-on-click] :or {expanded-class "expanded" collapsed-class "collapsed" expand-on-click (constantly nil)}}
    table-state row-data table-id]
   (with-meta [:td {:class    (if (row-expanded? table-state row-data table-id)
                                expanded-class collapsed-class)
-                   :on-click (toggle-child-row-fn table-state row-data table-id)}]
+                   :on-click (toggle-child-row-fn table-state row-data table-id expand-on-click)}]
              {:key [row-data "expand-button" table-id]}))
 
 (defn add-expand-button
@@ -179,6 +181,9 @@
        `:expand-button-alignment` - `:left` or `:right` (default: `:right`)
        `:expanded-class`      - (optional) The CSS class to assign to expanded rows. Defaults to \"expanded\"
        `:collapsed-class`     - (optional) The CSS class to assign to collapsed rows. Defaults to \"collapsed\"
+       `:expand-on-click`     - (optional) A fn which takes row-data and a boolean parameter which reports if the child row is expanded.
+                                This function is invoked on the on-click of the child-row's expand button.
+                                It can be used to generate side-effects on the expanding/collapsing action for a child row.
 
    `:sortable-columns`   - A seq of `col-id` which dictates which columns will be sortable
    `:filterable-columns` - A seq of `col-id` which dictates which columns will be filterable


### PR DESCRIPTION
This change adds a new optional parameter passed to the child-row-opts.
The new parameter is a function which is invoked on the 'on-click' event
of the child-row's expand button. The function takes a row-data and a
boolean with the status of the child row (expanded/collapsed). This
function can be used to generate side-effect based on the status and
values of a single child row.